### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/001KerbalActuators/KerbalActuators.version
+++ b/GameData/WildBlueIndustries/001KerbalActuators/KerbalActuators.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Kerbal Actuators",
-    "URL":"https://raw.githubusercontent.com/Angel-125/KerbalActuators/master/GameData/WildBlueIndustries/KerbalActuators/KerbalActuators.version",
+    "URL":"https://github.com/Angel-125/KerbalActuators/raw/master/GameData/WildBlueIndustries/001KerbalActuators/KerbalActuators.version",
     "DOWNLOAD":"https://github.com/Angel-125/KerbalActuators/releases",
     "GITHUB":
     {


### PR DESCRIPTION
The version file's URL property is a 404.
Now it's fixed.

Tagging @Angel-125 because not everyone has GitHub notifications enabled for pull requests.